### PR TITLE
Correct ts types declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "gaussian-rng",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gaussian-rng",
-      "version": "1.0.0",
+      "version": "1.0.6",
       "license": "MIT",
-      "dependencies": {
-        "gaussian-rng": "^1.0.0"
-      },
       "devDependencies": {
         "@types/node": "^22.12.0",
         "@vitest/coverage-v8": "^3.0.5",
@@ -1407,12 +1404,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/gaussian-rng": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gaussian-rng/-/gaussian-rng-1.0.0.tgz",
-      "integrity": "sha512-PINFfLxJyxjYBlG5qV1wUeughaT4mlqHmMFWK3LSqi+Xxuo5uOZkjQkYbqLZblY9I50url15YW3A0QYO8nArLA==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "version": "1.0.6",
   "description": "A Gaussian random number generator with mean, standard deviation, and skew control.",
   "main": "dist/cjs/index.cjs",
-  "module": "dist/esm/index.js",
+  "module": "dist/index.js",
   "exports": {
-    "import": "./dist/esm/index.js",
+    "types": "./dist/types/index.d.ts",
+    "import": "./dist/index.js",
     "require": "./dist/cjs/index.cjs"
   },
-  "types": "dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "build": "tsc --project tsconfig.json && tsc --project tsconfig.cjs.json && mv dist/cjs/index.js dist/cjs/index.cjs",
     "test": "vitest",


### PR DESCRIPTION
The types declaration is configured to be found in ./dist - while the file resides in ./dist/types. That shoudl be corrected.

Furthermore, it seems package-lock had not been rebuilt for the newer version.

NB:  version number left untouched